### PR TITLE
improvement/ simplify boolean assertion

### DIFF
--- a/src/test/java/com/taxis99/zendesk/ZendeskApiTest.java
+++ b/src/test/java/com/taxis99/zendesk/ZendeskApiTest.java
@@ -145,7 +145,7 @@ public class ZendeskApiTest {
   public void testGetRecentTickets() throws ZendeskException {
     final Set<Ticket> recentTickets = zendeskApi.getRecentTickets();
     assertNotNull(recentTickets);
-    assertTrue("recent tickets should not be null", !recentTickets.isEmpty());
+    assertFalse("recent tickets should not be empty", recentTickets.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Avoid negation in an `assertTrue` or `assertFalse` test.
Identified by https://www.codacy.com/app/99taxis/zendesk-java-api/issues?&filters=W3siaWQiOiJDYXRlZ29yeSIsInZhbHVlcyI6WyJFcnJvciBQcm9uZSJdfV0=
Defined by https://pmd.github.io/pmd-5.3.3/pmd-java/rules/java/junit.html#SimplifyBooleanAssertion
